### PR TITLE
Fix: Usar bun para el comando de construcción del frontend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -14,7 +14,7 @@ services:
     name: frontend
     runtime: static
     rootDir: "Technology Inclusion pagina"
-    buildCommand: "npm install && npm run build"
+    buildCommand: "bun install && bun run build" # <-- CORRECCIÓN: Usando bun en lugar de npm
     staticPublishPath: "./Technology Inclusion pagina/dist"
     routes:
       - type: rewrite


### PR DESCRIPTION
se corrige la información en el archivo para indicarle a render la dependencias que se utilizan 