### PR TITLE
Fix: Usar cd en buildCommand para la ruta del frontend

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -13,9 +13,9 @@ services:
   - type: web
     name: frontend
     runtime: static
-    rootDir: "Technology Inclusion pagina"
-    buildCommand: "bun install && bun run build" # <-- CORRECCIÓN: Usando bun en lugar de npm
-    staticPublishPath: "./Technology Inclusion pagina/dist"
+    # Se elimina rootDir y se usa `cd` en el buildCommand para ser más explícitos
+    buildCommand: "cd \"Technology Inclusion pagina\" && bun install && bun run build"
+    staticPublishPath: "Technology Inclusion pagina/dist" # Esta ruta es relativa a la raíz del repo
     routes:
       - type: rewrite
         source: /*


### PR DESCRIPTION
ahora actualizamos a ruta   buildCommand, para que se despliegue